### PR TITLE
Remove concourse git image. Most other images will have git installed

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:3.7 as resource
-RUN apk add --update \
-    git \
-    && rm -rf /var/cache/apk/*
-
-FROM resource


### PR DESCRIPTION
One dependency:
https://github.com/search?q=org%3ATeliaSoneraNorge+teliaoss%2Fconcourse-git&type=Code

PR to fix this here:
https://github.com/TeliaSoneraNorge/lambda-terraform-workshop/pull/30

Also need to delete the repository:
https://hub.docker.com/r/teliaoss/concourse-git/