### PR TITLE
Simplify terraform versions

### DIFF
--- a/terraform/0.11.10/Dockerfile
+++ b/terraform/0.11.10/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.11.10 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.11.6/Dockerfile
+++ b/terraform/0.11.6/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.11.6 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.11.7/Dockerfile
+++ b/terraform/0.11.7/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.11.7 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.11.8/Dockerfile
+++ b/terraform/0.11.8/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.11.8 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.11.9/Dockerfile
+++ b/terraform/0.11.9/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.11.9 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.11/Dockerfile
+++ b/terraform/0.11/Dockerfile
@@ -1,0 +1,10 @@
+FROM hashicorp/terraform:0.11.14 as resource
+RUN apk add --update --no-cache \
+    ncurses \
+    make \
+    curl
+RUN curl -sL https://taskfile.dev/install.sh | sh
+
+FROM resource
+ENTRYPOINT [ "terraform" ]
+CMD [ "--help" ]

--- a/terraform/0.12.5/Dockerfile
+++ b/terraform/0.12.5/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorp/terraform:0.12.5 as resource
-RUN apk add --update --no-cache \
-    make
-FROM resource
-ENTRYPOINT [ "terraform" ]
-CMD [ "--help" ]

--- a/terraform/0.12/Dockerfile
+++ b/terraform/0.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.7 as resource
+FROM hashicorp/terraform:0.12.9 as resource
 RUN apk add --update --no-cache \
     ncurses \
     make \


### PR DESCRIPTION
We won't delete existing images, but going forward I suggest we just have a single docker tag which follows patch updates from terraform.