### PR TITLE
chore(fly): Update version of Concourse CI

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest as resource
 
-ENV CONCOURSE_VERSION=5.5.1
+ENV CONCOURSE_VERSION=7.2.0
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
Bump version of Concourse CI from 5.5.1 to 7.2.0, as outlined in #27.